### PR TITLE
Let's mention that sslsecure.vim require Vim 7.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ call dein#add('chr4/sslsecure.vim')
 Plugin 'chr4/sslsecure.vim'
 ```
 
+Note that sslsecure.vim require Vim 7.3 or greater.
 
 ### Archlinux
 


### PR DESCRIPTION
Let's note that sslsecure.vim requires Vim 7.3 or later. It may sound stupid, but someone is still using the old vim version.

I allowed edits from maintainers, so please feel free to change my PR. Thanks!