### PR TITLE
Avoid Duplicating Matches

### DIFF
--- a/plugin/sslsecure.vim
+++ b/plugin/sslsecure.vim
@@ -112,7 +112,7 @@ endfunction
 " Put all autocmd statements into an augroup
 augroup sslsecure
   autocmd!
-  autocmd BufWinEnter * call s:addmatches()
+  autocmd BufWinEnter,WinEnter * call s:addmatches()
 augroup END
 
 " Highlight both groups as errors

--- a/plugin/sslsecure.vim
+++ b/plugin/sslsecure.vim
@@ -20,7 +20,7 @@ let s:end   = "\\v($|\\s|'|\"|,|\\.|;|\\}|\\]|\\))\\m"
 let s:delimiter = '[:+_-]'
 
 " This function highlights a keyword according to the rules specified above
-function s:genmatch(keyword, eop, exclude)
+function s:genmatch(keyword, eop, exclude) abort
   " _DES :+DES :DES
   call matchadd('insecureSSLProtocol', '\v(_|:\+?)\m\zs' . a:keyword . '\ze' . '\(' . s:delimiter . '\|' . s:end . '\)')
 
@@ -39,73 +39,80 @@ function s:genmatch(keyword, eop, exclude)
   call matchadd('insecureSSLProtocol', s:begin . '\zs' . a:keyword . '\ze' . s:delimiter . '\S')
 endfunction
 
-
 " Generate patterns to highlight insecure ciphers.
 " Reference: https://www.openssl.org/docs/man1.0.2/apps/ciphers.html
 "
 " Protocol matching condition
 let s:protocol = '\v(TLS|tls|SSL|ssl)[A-Za-z0-9\._-]*([Pp]rotocol|[Oo]ption)\m.*'
 
-" Put all autocmd statements into an augroup
-augroup sslsecure
-  autocmd!
+function s:addmatches() abort
+  if exists('w:sslsecure_applied')
+    return
+  endif
 
-  autocmd BufWinEnter * call s:genmatch('SSLv3', '', '')
-  autocmd BufWinEnter * call s:genmatch('SSLv2', '', '')
-  autocmd BufWinEnter * call s:genmatch('HIGH', '', '')
-  autocmd BufWinEnter * call s:genmatch('MEDIUM', '', '')
-  autocmd BufWinEnter * call s:genmatch('LOW', '', '')
-  autocmd BufWinEnter * call s:genmatch('DEFAULT', '', '')
-  autocmd BufWinEnter * call s:genmatch('COMPLEMENTOFDEFAULT', '', '')
-  autocmd BufWinEnter * call s:genmatch('ALL', '', '')
-  autocmd BufWinEnter * call s:genmatch('COMPLEMENTOFALL', '', '')
+  let w:sslsecure_applied = 1
+  call s:genmatch('SSLv3', '', '')
+  call s:genmatch('SSLv2', '', '')
+  call s:genmatch('HIGH', '', '')
+  call s:genmatch('MEDIUM', '', '')
+  call s:genmatch('LOW', '', '')
+  call s:genmatch('DEFAULT', '', '')
+  call s:genmatch('COMPLEMENTOFDEFAULT', '', '')
+  call s:genmatch('ALL', '', '')
+  call s:genmatch('COMPLEMENTOFALL', '', '')
 
   " SHA ciphers are only used in HMAC with all known OpenSSL/ LibreSSL cipher suites and MAC
   " usage is still considered safe
-  " autocmd BufWinEnter * call s:genmatch('SHA', '\D', '') " Match SHA without matching SHA256+
-  " autocmd BufWinEnter * call s:genmatch('SHA1', '', '')
-  autocmd BufWinEnter * call s:genmatch('MD5', '', '')
-  autocmd BufWinEnter * call s:genmatch('RC2', '', '')
-  autocmd BufWinEnter * call s:genmatch('RC4' , '', '')
-  autocmd BufWinEnter * call s:genmatch('3DES', '', '')
-  autocmd BufWinEnter * call s:genmatch('DES', '', '')
-  autocmd BufWinEnter * call s:genmatch('aDSS', '', '')
-  autocmd BufWinEnter * call s:genmatch('DSS', '', 'a')
-  autocmd BufWinEnter * call s:genmatch('PSK', '', '')
-  autocmd BufWinEnter * call s:genmatch('IDEA', '', '')
-  autocmd BufWinEnter * call s:genmatch('SEED', '', '')
-  autocmd BufWinEnter * call s:genmatch('EXP[0-9A-Za-z]*', '', '')
-  autocmd BufWinEnter * call s:genmatch('aGOST[0-9A-Za-z]*', '', '')
-  autocmd BufWinEnter * call s:genmatch('kGOST[0-9A-Za-z]*', '', '')
-  autocmd BufWinEnter * call s:genmatch('GOST[0-9A-Za-z]*', '', 'ak')
-  autocmd BufWinEnter * call s:genmatch('[kae]\?FZA', '', '')
-  autocmd BufWinEnter * call s:genmatch('ECB', '', '')
-  autocmd BufWinEnter * call s:genmatch('[aes]\?NULL', '', '')
+  " call s:genmatch('SHA', '\D', '') " Match SHA without matching SHA256+
+  " call s:genmatch('SHA1', '', '')
+  call s:genmatch('MD5', '', '')
+  call s:genmatch('RC2', '', '')
+  call s:genmatch('RC4' , '', '')
+  call s:genmatch('3DES', '', '')
+  call s:genmatch('DES', '', '')
+  call s:genmatch('aDSS', '', '')
+  call s:genmatch('DSS', '', 'a')
+  call s:genmatch('PSK', '', '')
+  call s:genmatch('IDEA', '', '')
+  call s:genmatch('SEED', '', '')
+  call s:genmatch('EXP[0-9A-Za-z]*', '', '')
+  call s:genmatch('aGOST[0-9A-Za-z]*', '', '')
+  call s:genmatch('kGOST[0-9A-Za-z]*', '', '')
+  call s:genmatch('GOST[0-9A-Za-z]*', '', 'ak')
+  call s:genmatch('[kae]\?FZA', '', '')
+  call s:genmatch('ECB', '', '')
+  call s:genmatch('[aes]\?NULL', '', '')
 
   " Anonymous cipher suites should never be used
-  autocmd BufWinEnter * call s:genmatch('anon', '', '')       " Keyword used by e.g. rustls
-  autocmd BufWinEnter * call s:genmatch('DH', '[^E]', 'ECa')  " Try to match DH without DHE, EDH, EECDH, etc.
-  autocmd BufWinEnter * call s:genmatch('ECDH', '[^E]', 'EA') " Do not match EECDH, ECDHE
-  autocmd BufWinEnter * call s:genmatch('ADH', '', '')
-  autocmd BufWinEnter * call s:genmatch('kDHE', '', '')
-  autocmd BufWinEnter * call s:genmatch('kEDH', '', '')
-  autocmd BufWinEnter * call s:genmatch('kECDHE', '', '')
-  autocmd BufWinEnter * call s:genmatch('kEECDH', '', '')
-  autocmd BufWinEnter * call s:genmatch('AECDH', '', '[^E]')
+  call s:genmatch('anon', '', '')       " Keyword used by e.g. rustls
+  call s:genmatch('DH', '[^E]', 'ECa')  " Try to match DH without DHE, EDH, EECDH, etc.
+  call s:genmatch('ECDH', '[^E]', 'EA') " Do not match EECDH, ECDHE
+  call s:genmatch('ADH', '', '')
+  call s:genmatch('kDHE', '', '')
+  call s:genmatch('kEDH', '', '')
+  call s:genmatch('kECDHE', '', '')
+  call s:genmatch('kEECDH', '', '')
+  call s:genmatch('AECDH', '', '[^E]')
 
   " Check for insecure protocols after keywords that could specify TLS/ SSL protocols
-  autocmd BufWinEnter * call matchadd('insecureSSLProtocol', s:protocol . '[^!-]\zs\cSSlv2')
-  autocmd BufWinEnter * call matchadd('insecureSSLProtocol', s:protocol . '[^!-]\zs\cSSlv3')
+  call matchadd('insecureSSLProtocol', s:protocol . '[^!-]\zs\cSSlv2')
+  call matchadd('insecureSSLProtocol', s:protocol . '[^!-]\zs\cSSlv3')
 
   " Golang uses `MinVersion: tls.VersionSSL30`
-  autocmd BufWinEnter * call matchadd('insecureSSLProtocol', 'tls\.\zsVersionSSL30')
+  call matchadd('insecureSSLProtocol', 'tls\.\zsVersionSSL30')
 
   " HAProxy bind option
-  autocmd BufWinEnter * call matchadd('insecureSSLProtocol', s:protocol . '\zsforce-sslv3')
+  call matchadd('insecureSSLProtocol', s:protocol . '\zsforce-sslv3')
 
-" TLSv1 is vulnerable to the BEAST attack. Should be disabled if possible.
-" TODO: TLSv1.0 is not matched yet
-" autocmd BufWinEnter * cal matchadd('insecureSSLProtocol', s:protocol . '[^!-]\zs\cTLSv1\ze[^\.]')
+  " TLSv1 is vulnerable to the BEAST attack. Should be disabled if possible.
+  " TODO: TLSv1.0 is not matched yet
+  " call matchadd('insecureSSLProtocol', s:protocol . '[^!-]\zs\cTLSv1\ze[^\.]')
+endfunction
+
+" Put all autocmd statements into an augroup
+augroup sslsecure
+  autocmd!
+  autocmd BufWinEnter * call s:addmatches()
 augroup END
 
 " Highlight both groups as errors


### PR DESCRIPTION
Hi! This PR moves all the separate autocmd lines into one big function that has a guard at the top which is window-scoped to align with the scope of vim's matches, keeping duplicate matches from being created.  It also autoruns this new function on WinEnter, which gets the matches created when making a new split, and adds 'abort' to the two functions so they stop and cry on any errors.

In its current state, this plugin will only be responsible for at most 179 matches per window in a vim process. :smile:

Fixes #5 